### PR TITLE
Fixing error on catching error object

### DIFF
--- a/components/CheckoutForm.jsx
+++ b/components/CheckoutForm.jsx
@@ -81,7 +81,7 @@ const CheckoutForm = ({ price, onSuccessfulCheckout }) => {
 
       onSuccessfulCheckout();
     } catch (err) {
-      setCheckoutError(err);
+      setCheckoutError(err.message);
     }
   };
 


### PR DESCRIPTION
If you catch an error when making a post request to the server, you can't pass an object to the CheckoutError component, because an object is not valid React child. The fix is to pass only a message property.