### PR TITLE
Include a note about environment variables usage with Next.js

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-# WARNING: If are using a recent version of Next.js, you may need to add prefix in order to expose your publishable key to the browser
+# WARNING: If are using a recent version of Next.js you may need to add a prefix in order to expose your publishable key to the browser
 # More info: https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables
 
 PUBLISHABLE_KEY=pk_test_1234

--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # WARNING: If are using a recent version of Next.js you may need to add a prefix in order to expose your publishable key to the browser
-# More info: https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables
+# More info: https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser
 
 PUBLISHABLE_KEY=pk_test_1234
 SECRET_KEY=sk_test_1234

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-# WARNING: If are using a recent version of Next.js you may need to add a prefix in order to expose your publishable key to the browser
+# WARNING: If are using a recent version of Next.js you may need to add a prefix to "PUBLISHABLE_KEY" so that Next.js makes it available in the  browser context
 # More info: https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser
 
 PUBLISHABLE_KEY=pk_test_1234

--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
-# WARNING: For Next.js users, you must add a prefix in order to expose your publishable key to the browser
-# See: https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables
+# WARNING: If are using a recent version of Next.js, you may need to add prefix in order to expose your publishable key to the browser
+# More info: https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables
 
 PUBLISHABLE_KEY=pk_test_1234
 SECRET_KEY=sk_test_1234

--- a/.env
+++ b/.env
@@ -1,2 +1,5 @@
+# WARNING: For Next.js users, you must add a prefix in order to expose your publishable key to the browser
+# See: https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables
+
 PUBLISHABLE_KEY=pk_test_1234
 SECRET_KEY=sk_test_1234


### PR DESCRIPTION
Adds a note to the .env file warning users about the proper usage of environment variables with recent versions of Next.js

Motivation:  Next.js changed the way it handles exposing environment variables on their 9.4 release.