### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Getting Started
 
 - clone this repo locally by clicking on "Clone or Download"
-- from a terminal, cd into the project folder `cd react-stripe-js-demo`
+- from a terminal, cd into the project folder `cd demo-react-stripe-js`
 - checkout the getting started branch `git checkout getting-started`
 - install the dependencies `npm install`
 - start developing! `npm run dev`


### PR DESCRIPTION
Hello! Love the repo.

I think you meant to put `cd demo-react-stripe-js` instead of `cd react-stripe-js-demo` in the README.